### PR TITLE
Fix coreos vagrant github address.

### DIFF
--- a/src/first-init.command
+++ b/src/first-init.command
@@ -10,7 +10,7 @@
 ### getting files from github and setting them up
 echo ""
 echo "Downloading latest coreos-vagrant files from github to tmp folder: "
-git clone https://github.com/coreos/coreos-vagrant/ ~/coreos-k8s-cluster/tmp
+git clone https://github.com/coreos/coreos-vagrant.git ~/coreos-k8s-cluster/tmp
 echo "Done downloading from github !!!"
 echo ""
 


### PR DESCRIPTION
https://github.com/coreos/coreos-vagrant/ url doen't work..

ERROR: Repository not found.
fatal: Could not read from remote repository.
